### PR TITLE
Loop interrupts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@boardzilla/core",
-  "version": "0.0.81",
+  "version": "0.0.82",
   "author": "Andrew Hull <aghull@gmail.com>",
   "license": "MIT",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@boardzilla/core",
-  "version": "0.0.82",
+  "version": "0.0.81",
   "author": "Andrew Hull <aghull@gmail.com>",
   "license": "MIT",
   "scripts": {

--- a/src/flow/enums.ts
+++ b/src/flow/enums.ts
@@ -44,9 +44,16 @@
  * @category Flow
  */
 export const Do = {
-  repeat: () => loopInterrupt[0] = LoopInterruptControl.repeat,
-  continue: () => loopInterrupt[0] = LoopInterruptControl.continue,
-  break: () => loopInterrupt[0] = LoopInterruptControl.break,
+  repeat: (loop?: string | Record<string, string>) => interrupt(LoopInterruptControl.repeat, typeof loop === 'string' ? loop : undefined),
+  continue: (loop?: string | Record<string, string>) => interrupt(LoopInterruptControl.continue, typeof loop === 'string' ? loop : undefined),
+  break: (loop?: string | Record<string, string>) => interrupt(LoopInterruptControl.break, typeof loop === 'string' ? loop : undefined),
+}
+
+/** @internal */
+export const loopInterrupt: {loop?: string, signal: LoopInterruptControl}[] = [];
+
+function interrupt(signal: LoopInterruptControl, loop?: string) {
+  loopInterrupt[0] = {loop, signal};
 }
 
 /** @internal */
@@ -61,6 +68,3 @@ export enum FlowControl {
   ok = "__OK__",
   complete = "__COMPLETE__"
 }
-
-/** @internal */
-export const loopInterrupt: [LoopInterruptControl?] = [];

--- a/src/flow/every-player.ts
+++ b/src/flow/every-player.ts
@@ -120,7 +120,7 @@ export default class EveryPlayer<P extends Player> extends Flow<P> {
 
   // intercept super.playOneStep so a single branch doesn't signal complete
   // without us checking all branches
-  playOneStep(): LoopInterruptControl | FlowControl | undefined {
+  playOneStep(): {name?: string, signal: LoopInterruptControl} | FlowControl | undefined {
     // step through each player over top of the normal super stepping
     const player = this.getPlayers().findIndex((_, p) => this.completed[p] === undefined);
 

--- a/src/flow/flow.ts
+++ b/src/flow/flow.ts
@@ -273,9 +273,7 @@ export default class Flow<P extends Player> {
     }
     if (result === FlowControl.ok || !result) return result;
     if (result !== FlowControl.complete) {
-      console.log('?', result.loop, this.name);
       if ('interrupt' in this && typeof this.interrupt === 'function' && (!result.loop || result.loop === this.name)) return this.interrupt(result.signal)
-      console.log('!', result.loop, this.name);
       return result;
     }
 

--- a/src/flow/flow.ts
+++ b/src/flow/flow.ts
@@ -1,6 +1,7 @@
 import { Player } from '../index.js';
 import { Board } from '../board/index.js';
 import { LoopInterruptControl, loopInterrupt, FlowControl } from './enums.js';
+import { Do } from './enums.js';
 
 import type Game from '../game.js';
 import type { WhileLoopPosition } from './while-loop.js';
@@ -9,9 +10,9 @@ import type { ForEachPosition } from './for-each.js';
 import type { SwitchCasePostion } from './switch-case.js';
 import type { ActionStepPosition } from './action-step.js';
 import type { EveryPlayerPosition } from './every-player.js';
-import { Argument, ActionStub } from '../action/action.js';
-import ActionStep from './action-step.js';
-import { Do } from './enums.js';
+import type { Argument, ActionStub } from '../action/action.js';
+import type ActionStep from './action-step.js';
+import type WhileLoop from './while-loop.js';
 
 /**
  * Several flow methods accept an argument of this type. This is an object
@@ -212,6 +213,11 @@ export default class Flow<P extends Player> {
     this.setPosition(this.fromJSON(positionJSON), sequence, false);
   }
 
+  currentLoop(name?: string): WhileLoop<P> | undefined {
+    if ('interrupt' in this && (!name || name === this.name)) return this as unknown as WhileLoop<P>;
+    return this.parent?.currentLoop();
+  }
+
   currentProcessor(): Flow<P> | undefined {
     if (this.step instanceof Flow) return this.step.currentProcessor();
     if (this.type === 'action' || this.type === 'parallel') return this;
@@ -254,22 +260,22 @@ export default class Flow<P extends Player> {
    * loop. Returns undefined if now waiting for player input. override
    * for self-contained flows that do not have subflows.
    */
-  playOneStep(): LoopInterruptControl | FlowControl | undefined {
+  playOneStep(): {loop?: string, signal: LoopInterruptControl} | FlowControl | undefined {
     const step = this.step;
-    let result: LoopInterruptControl | FlowControl | undefined = FlowControl.complete;
+    let result: {loop?: string, signal: LoopInterruptControl} | FlowControl | undefined = FlowControl.complete;
     if (step instanceof Function) {
-      loopInterrupt[0] = undefined;
-      step(this.flowStepArgs());
-      result = loopInterrupt[0] ?? FlowControl.complete;
+      if (!loopInterrupt[0]) step(this.flowStepArgs());
+      result = FlowControl.complete;
+      if (loopInterrupt[0]) result = loopInterrupt.shift();
     } else if (step instanceof Flow) {
       if ('awaitingAction' in step && (step as ActionStep<P>).awaitingAction()) return; // awaiting action
       result = step.playOneStep();
     }
     if (result === FlowControl.ok || !result) return result;
     if (result !== FlowControl.complete) {
-      if ('advance' in this && typeof this.advance === 'function' && result === LoopInterruptControl.continue) return this.advance();
-      if ('repeat' in this && typeof this.repeat === 'function' && result === LoopInterruptControl.repeat) return this.repeat();
-      if ('exit' in this && typeof this.exit === 'function' && result === LoopInterruptControl.break) return this.exit();
+      console.log('?', result.loop, this.name);
+      if ('interrupt' in this && typeof this.interrupt === 'function' && (!result.loop || result.loop === this.name)) return this.interrupt(result.signal)
+      console.log('!', result.loop, this.name);
       return result;
     }
 
@@ -296,7 +302,11 @@ export default class Flow<P extends Player> {
       if (step) console.debug(`Advancing flow:\n ${this.stacktrace()}`);
     } while (step === FlowControl.ok && this.game.phase !== 'finished')
     //console.debug("Game Flow:\n" + this.stacktrace());
-    if (step === LoopInterruptControl.continue || step === LoopInterruptControl.repeat || step === LoopInterruptControl.break) throw Error("Cannot skip/repeat/break when not in a loop");
+    if (typeof step === 'object') {
+      if (step.signal === LoopInterruptControl.continue) throw Error("Cannot use Do.continue when not in a loop");
+      if (step.signal === LoopInterruptControl.repeat) throw Error("Cannot use Do.repeat when not in a loop");
+      if (step.signal === LoopInterruptControl.break) throw Error("Cannot use Do.break when not in a loop");
+    }
     if (step === FlowControl.complete) this.game.finish();
   }
 

--- a/src/flow/while-loop.ts
+++ b/src/flow/while-loop.ts
@@ -40,7 +40,9 @@ export default class WhileLoop<P extends Player> extends Flow<P> {
 
   advance() {
     if (this.position.index > 10000) throw Error(`Endless loop detected: ${this.name}`);
-    if (this.position.index === -1) return this.exit();
+    if (this.position.index === -1) {
+      return this.exit();
+    }
     const position: typeof this.position = { ...this.position, index: this.position.index + 1 };
     if (this.next && this.position.value !== undefined) position.value = this.next(this.position.value);
     if (!this.whileCondition(position)) return this.exit();

--- a/src/test/flow_test.ts
+++ b/src/test/flow_test.ts
@@ -4,6 +4,7 @@ import spies from 'chai-spies';
 import Flow from '../flow/flow.js';
 import {
   playerActions,
+  loop,
   whileLoop,
   forLoop,
   forEach,
@@ -498,22 +499,75 @@ describe('Loop short-circuiting', () => {
     expect(stepSpy2).not.to.have.been.called.with('start', 13);
   });
 
-  it('can break out of named loop', () => {
-    const stepSpy1 = chai.spy((x:number) => x === 12 ? Do.break('loop') : undefined);
-    const stepSpy2 = chai.spy((_: string, x:number) => {x});
+  it('can continue to a named loop', () => {
+    const stepSpy1 = chai.spy((x:number) => x === 12 ? Do.continue('loop') : undefined);
+    const stepSpy2 = chai.spy();
+    const stepSpy3 = chai.spy();
     const shortLoop = forLoop({ name: 'loop', initial: 0, next: loop => loop + 1, while: loop => loop < 2, do: [
-      ({ loop2 }) => stepSpy2('start', loop2),
+      stepSpy2,
       forLoop({ name: 'loop2', initial: 10, next: loop2 => loop2 + 1, while: loop2 => loop2 < 20, do: [
         ({ loop2 }) => stepSpy1(loop2),
       ]}),
-      ({ loop2 }) => stepSpy2('end', loop2)
+      stepSpy3
     ]});
     shortLoop.reset();
     shortLoop.playOneStep();
     shortLoop.playOneStep();
-    shortLoop.playOneStep(); // stop
+    shortLoop.playOneStep();
+    expect(shortLoop.flowStepArgs()).to.deep.equal({ loop: 0, loop2: 12 });
+    expect(stepSpy2).to.have.been.called.exactly(1);
+    expect(stepSpy1).to.have.been.called.exactly(2);
+    expect(stepSpy3).to.have.been.called.exactly(0);
+
+    shortLoop.playOneStep(); // continue to outer loop
+    expect(shortLoop.flowStepArgs()).to.deep.equal({ loop: 1 });
+    expect(stepSpy1).to.have.been.called.exactly(3);
+    expect(stepSpy2).to.have.been.called.exactly(1);
+    expect(stepSpy3).to.have.been.called.exactly(0);
+
+    shortLoop.playOneStep();
+    expect(shortLoop.flowStepArgs()).to.deep.equal({ loop: 1, loop2: 10 });
+    expect(stepSpy1).to.have.been.called.exactly(3);
+    expect(stepSpy2).to.have.been.called.exactly(2);
+  });
+
+  it('can break to a named loop', () => {
+    const stepSpy1 = chai.spy((x:number) => x === 12 ? Do.break('loop') : undefined);
+    const stepSpy2 = chai.spy();
+    const stepSpy3 = chai.spy();
+    const stepSpy4 = chai.spy();
+    const shortLoop = loop(
+      forLoop({ name: 'loop', initial: 0, next: loop => loop + 1, while: loop => loop < 2, do: [
+        stepSpy2,
+        forLoop({ name: 'loop2', initial: 10, next: loop2 => loop2 + 1, while: loop2 => loop2 < 20, do: [
+          ({ loop2 }) => stepSpy1(loop2),
+        ]}),
+        stepSpy3
+      ]}),
+      stepSpy4
+    )
+    shortLoop.reset();
+    shortLoop.playOneStep();
+    shortLoop.playOneStep();
+    shortLoop.playOneStep();
+    expect(shortLoop.flowStepArgs()).to.deep.equal({ loop: 0, loop2: 12 });
+    expect(stepSpy2).to.have.been.called.exactly(1);
+    expect(stepSpy1).to.have.been.called.exactly(2);
+    expect(stepSpy3).to.have.been.called.exactly(0);
+    expect(stepSpy4).to.have.been.called.exactly(0);
+
     shortLoop.playOneStep(); // break out of outer loop
-    console.log(shortLoop.stacktrace());
+    shortLoop.playOneStep(); // resume at topmost loop
+    expect(shortLoop.flowStepArgs()).to.deep.equal({ loop: 0 });
+    expect(stepSpy2).to.have.been.called.exactly(1);
+    expect(stepSpy1).to.have.been.called.exactly(3);
+    expect(stepSpy3).to.have.been.called.exactly(0);
+    expect(stepSpy4).to.have.been.called.exactly(1);
+
+    shortLoop.playOneStep(); // all loops starting over
+    expect(shortLoop.flowStepArgs()).to.deep.equal({ loop: 0, loop2: 10 });
+    expect(stepSpy2).to.have.been.called.exactly(2);
+
   });
 
   it('can repeat out of processMove', () => {
@@ -574,9 +628,7 @@ describe('Loop short-circuiting', () => {
     shortLoop.reset();
     shortLoop.play();
     shortLoop.processMove({ name: 'breakAction', args: {}, player: 1 });
-    console.log(shortLoop.stacktrace());
     shortLoop.play();
-    console.log(shortLoop.stacktrace());
     expect(stepSpy1).not.to.have.been.called;
     expect(stepSpy2).to.have.been.called;
   });

--- a/src/test/flow_test.ts
+++ b/src/test/flow_test.ts
@@ -499,6 +499,14 @@ describe('Loop short-circuiting', () => {
     expect(stepSpy2).not.to.have.been.called.with('start', 13);
   });
 
+  it('rejects interrupt with no loop', () => {
+    const badLoop = ifElse({ if: () => true, do: Do.break })
+    // @ts-ignore mock game
+    badLoop.game = {phase: 'started'};
+    badLoop.reset();
+    expect(() => badLoop.play()).to.throw(/Do\.break/);
+  });
+
   it('can continue to a named loop', () => {
     const stepSpy1 = chai.spy((x:number) => x === 12 ? Do.continue('loop') : undefined);
     const stepSpy2 = chai.spy();


### PR DESCRIPTION
- allow interrupts to be called anywhere (namely during move processing)
- allow interrupts to take an argument for a named loop
- interrupts continue to throw if called outside a loop (now esp important)
- interrupts now also throw if not in the named loop