### PR TITLE
Move validation

### DIFF
--- a/src/action/action.ts
+++ b/src/action/action.ts
@@ -453,6 +453,7 @@ export default class Action<P extends Player, A extends Record<string, Argument<
       prompt: options?.prompt,
       validation: options?.validate,
       confirm: options?.confirm,
+      skipIf: options?.skipIf,
       selectFromChoices: { choices }
     }));
     return this as unknown as Action<P, A & {[key in N]: T}>;

--- a/src/action/selection.ts
+++ b/src/action/selection.ts
@@ -122,6 +122,7 @@ export default class Selection<P extends Player> {
   initial?: Argument<P> | ((args: Record<string, Argument<P>>) => Argument<P>);
   regexp?: RegExp;
   value?: Argument<P>;
+  invalidOptions: {option: Argument<P>, error: string}[] = [];
 
   constructor(name: string, s: SelectionDefinition<P> | Selection<P>) {
     this.name = name;
@@ -294,18 +295,12 @@ export default class Selection<P extends Player> {
     }
   }
 
-  overrideOptions(options: SingleArgument<P>[]): ResolvedSelection<P> {
+  overrideOptions(this: ResolvedSelection<P>, options: SingleArgument<P>[]) {
     if (this.type === 'board') {
       this.boardChoices = options as GameElement<P>[];
-      return this as ResolvedSelection<P>;
+    } else {
+      this.choices = options as GameElement<P>[];
     }
-    return new Selection(this.name, {
-      selectFromChoices: {
-        choices: options,
-        //min: selection.min, TODO
-        //max: selection.max
-      }
-    }) as ResolvedSelection<P>;
   }
 
   toString(): string {

--- a/src/action/selection.ts
+++ b/src/action/selection.ts
@@ -244,7 +244,7 @@ export default class Selection<P extends Player> {
   }
 
   isMulti() {
-    return this.min !== undefined || this.max !== undefined;
+    return (this.type === 'choices' || this.type === 'board') && (this.min !== undefined || this.max !== undefined);
   }
 
   isBoardChoice() {

--- a/src/board/board.ts
+++ b/src/board/board.ts
@@ -124,7 +124,6 @@ export default class Board<P extends Player<P, B> = any, B extends Board<P, B> =
 
   fromJSON(boardJSON: ElementJSON[]) {
     let { className, children, _id, order, ...rest } = boardJSON[0];
-    if (this._ctx.game) rest = deserializeObject({...rest}, this._ctx.game);
     if (this.constructor.name !== className) throw Error(`Cannot create board from JSON. ${className} must equal ${this.constructor.name}`);
 
     // reset all on self
@@ -136,6 +135,7 @@ export default class Board<P extends Player<P, B> = any, B extends Board<P, B> =
     this._ctx.removed.createChildrenFromJSON(boardJSON.slice(1), '1');
     if (order) this._t.order = order;
 
+    if (this._ctx.game) rest = deserializeObject({...rest}, this._ctx.game);
     Object.assign(this, {...rest});
     this.assignAttributesFromJSON(children || [], '0');
     this._ctx.removed.assignAttributesFromJSON(boardJSON.slice(1), '1');

--- a/src/test/actions_test.ts
+++ b/src/test/actions_test.ts
@@ -170,20 +170,16 @@ describe('Actions', () => {
           validate: ({ lumber, steel, meat, plastic }) => lumber + steel + meat + plastic > 0
         });
       const move = testAction._getPendingMoves({});
-      if (!move) {
-        expect(move).to.not.be.undefined;
-      } else {
-        expect(move[0].selections.length).to.equal(2);
-        expect(move[0].selections[0].name).to.equal('lumber');
-        expect(move[0].selections[1].name).to.equal('meat');
-      }
+      expect(move).to.not.be.undefined;
+      expect(move?.[0].selections.length).to.equal(2);
+      expect(move?.[0].selections[0].name).to.equal('lumber');
+      expect(move?.[0].selections[1].name).to.equal('meat');
+
       const move2 = testAction._getPendingMoves({lumber: 1, meat: 0});
-      if (!move2) {
-        expect(move2).to.not.be.undefined;
-      } else {
-        expect(move2[0].selections.length).to.equal(1);
-        expect(move2[0].selections[0].name).to.equal('plastic'); // bit odd, but this is skippable
-      }
+      expect(move2).to.not.be.undefined;
+      expect(move2?.[0].selections.length).to.equal(1);
+      expect(move2?.[0].selections[0].name).to.equal('plastic'); // bit odd, but this is skippable
+
       const move3 = testAction._getPendingMoves({lumber: 0, meat: 0});
       expect(move3).to.be.undefined;
     });

--- a/src/test/actions_test.ts
+++ b/src/test/actions_test.ts
@@ -221,8 +221,8 @@ describe('Actions', () => {
       testAction = new Action({ prompt: 'p' })
         .chooseFrom('r', ['oil', 'garbage'])
         .chooseNumber('n', {
-        max: ({ r }) => r === 'oil' ? 3 : 1
-      });
+          max: ({ r }) => r === 'oil' ? 3 : 1
+        });
     });
 
     it('shows first selection', () => {
@@ -280,6 +280,29 @@ describe('Actions', () => {
       expect(moves![0].selections.length).to.equal(1);
       expect(moves![0].selections[0].type).to.equal('choices');
       expect(moves![0].selections[0].choices).to.deep.equal(['oil']);
+    });
+  });
+
+  describe('validation rules', () => {
+    let testAction: Action<any, {r: string, n: number}>;
+    beforeEach(() => {
+      testAction = new Action({ prompt: 'p' })
+        .chooseFrom(
+          'r', ['oil', 'garbage', 'steel'],
+          {
+            validate: ({r}) => r === 'steel' ? 'no steel allowed' : true
+          }
+        ).chooseNumber(
+          'n', {
+            max: ({ r }) => r === 'oil' ? 3 : 1
+          }
+        );
+    });
+
+    it('validates choices', () => {
+      const moves = testAction._getPendingMoves({});
+      expect(moves?.[0].selections[0].choices).to.deep.equal(['oil', 'garbage']);
+      expect(moves?.[0].selections[0].invalidOptions).to.deep.equal([{option: 'steel', error: 'no steel allowed'}]);
     });
   });
 

--- a/src/test/actions_test.ts
+++ b/src/test/actions_test.ts
@@ -178,7 +178,9 @@ describe('Actions', () => {
       const move2 = testAction._getPendingMoves({lumber: 1, meat: 0});
       expect(move2).to.not.be.undefined;
       expect(move2?.[0].selections.length).to.equal(1);
-      expect(move2?.[0].selections[0].name).to.equal('plastic'); // bit odd, but this is skippable
+      // bit odd, returns a forced choice so we can show something, although the UI will skip this ultimately
+      expect(move2?.[0].selections[0].name).to.equal('plastic');
+      console.log(move2?.[0].args);
 
       const move3 = testAction._getPendingMoves({lumber: 0, meat: 0});
       expect(move3).to.be.undefined;

--- a/src/test/fixtures/games.ts
+++ b/src/test/fixtures/games.ts
@@ -133,6 +133,19 @@ export const starterGameWithTilesConfirm = gameFactory(game => {
   });
 });
 
+export const starterGameWithTilesValidate = gameFactory(game => {
+  game.defineActions({
+    take: player => game.action({
+      prompt: 'Choose a token',
+    }).chooseOnBoard(
+      'token', $.pool.all(Token),
+    ).placePiece(
+      'token', player.my('mat')!,
+      { validate: ({ token }) => (token.column + token.row) % 2 !== 0 ? 'must be black square' : undefined, }
+    ),
+  });
+});
+
 export const starterGameWithTilesCompound = gameFactory(game => {
   game.defineActions({
     take: player => game.action({

--- a/src/test/fixtures/games.ts
+++ b/src/test/fixtures/games.ts
@@ -81,6 +81,19 @@ export const starterGameWithConfirm = gameFactory(game => {
   });
 });
 
+export const starterGameWithValidate = gameFactory(game => {
+  game.defineActions({
+    take: player => game.action({
+      prompt: 'Choose a token',
+    }).chooseOnBoard(
+      'token', $.pool.all(Token),
+      { validate: ({ token }) => token.container()!.first(Token) === token ? 'not first' : undefined }
+    ).move(
+      'token', player.my('mat')!,
+    ),
+  });
+});
+
 export const starterGameWithCompoundMove = gameFactory(game => {
   game.defineActions({
     take: player => game.action({

--- a/src/test/ui_test.ts
+++ b/src/test/ui_test.ts
@@ -18,6 +18,7 @@ import {
   starterGameWithCompoundMove,
   starterGameWithTiles,
   starterGameWithTilesConfirm,
+  starterGameWithTilesValidate,
   starterGameWithTilesCompound,
   Token
 } from './fixtures/games.js';
@@ -164,12 +165,15 @@ describe('UI', () => {
     state = store.getState();
 
     state.setPlacement({ column: 2, row: 2 });
-    token = state.game.board.first(Token)!;
+    const ghost = state.game.board.first(Token)!;
+    token = state.game.board.first('pool')!.first(Token)!;
 
     expect(history.length).to.equal(0);
     expect(state.pendingMoves?.[0].selections[0].type).to.equal('place');
-    expect(token.column).to.equal(2);
-    expect(token.row).to.equal(2);
+    expect(ghost.column).to.equal(2);
+    expect(ghost.row).to.equal(2);
+    expect(token.column).to.be.undefined;
+    expect(token.row).to.be.undefined;
 
     state.selectPlacement({ column: 2, row: 2 });
     expect(history.length).to.equal(1);
@@ -202,6 +206,31 @@ describe('UI', () => {
     expect(token.row).to.equal(2);
     expect(state.game.board.first('mat')!.all(Token).length).to.equal(1); // ghost piece
     expect(state.game.board.first('pool')!.all(Token).length).to.equal(4);
+  });
+
+  it("places pieces with validate", () => {
+    const store = getGameStore(starterGameWithTilesValidate);
+
+    updateStore(store, 2, {tokens: 4});
+    let state = store.getState();
+    let token = state.game.board.first(Token)!;
+    const clickMoves = state.boardSelections[token.branch()].clickMoves;
+    state.selectElement(clickMoves, token);
+    state = store.getState();
+
+    state.setPlacement({ column: 1, row: 2 });
+    state = store.getState();
+    const ghost = state.placement?.piece!
+
+    expect(ghost.column).to.equal(1);
+    expect(ghost.row).to.equal(2);
+    expect(state.placement?.invalid).to.be.true;
+
+    state.selectPlacement({ column: 1, row: 2 });
+
+    state = store.getState();
+    expect(state.error).to.equal('must be black square');
+    expect(history.length).to.equal(0);
   });
 
   it("continues compound place piece", () => {

--- a/src/test/ui_test.ts
+++ b/src/test/ui_test.ts
@@ -14,6 +14,7 @@ import type { SerializedMove } from '../game.js';
 import {
   starterGame,
   starterGameWithConfirm,
+  starterGameWithValidate,
   starterGameWithCompoundMove,
   starterGameWithTiles,
   starterGameWithTilesConfirm,
@@ -90,6 +91,18 @@ describe('UI', () => {
 
     expect(history.length).to.equal(1);
     expect(state.pendingMoves).to.deep.equal([]);
+  });
+
+  it("validates", () => {
+    const store = getGameStore(starterGameWithValidate);
+
+    updateStore(store, 2, {tokens: 4});
+    let state = store.getState();
+    let token = state.game.board.first(Token)!;
+    const clickMoves = state.boardSelections[token.branch()].clickMoves;
+
+    expect(state.boardSelections[token.branch()].error).to.equal('not first');
+    expect(clickMoves.length).to.equal(0);
   });
 
   it("cancels confirm", () => {

--- a/src/ui/Main.tsx
+++ b/src/ui/Main.tsx
@@ -131,7 +131,7 @@ export default ({ minPlayers, maxPlayers, setupComponents }: {
   maxPlayers: number,
   setupComponents: Record<string, (p: SetupComponentProps) => JSX.Element>
 }) => {
-  const [game, setFinished, setError, updateState, setUserOnline, announcementIndex] = gameStore(s => [s.game, s.setFinished, s.setError, s.updateState, s.setUserOnline, s.announcementIndex]);
+  const [game, setFinished, updateState, setUserOnline, announcementIndex] = gameStore(s => [s.game, s.setFinished, s.updateState, s.setUserOnline, s.announcementIndex]);
   const [settings, setSettings] = useState<GameSettings>();
   const [users, setUsers] = useState<User[]>([]);
   const [readySent, setReadySent] = useState<boolean>(false);

--- a/src/ui/assets/styles/game.scss
+++ b/src/ui/assets/styles/game.scss
@@ -197,6 +197,12 @@ html, body { height: 100% }
       }
     }
 
+    .invalid {
+      > .bz-default {
+        background: #fcc;
+      }
+    }
+
     .Piece.selected {
       > .bz-default {
         transform: scale(1.2);

--- a/src/ui/assets/styles/game.scss
+++ b/src/ui/assets/styles/game.scss
@@ -98,6 +98,9 @@ html, body { height: 100% }
           width: 100%;
           height: 100%;
           background: #ccc;
+          html.dark & {
+            background: #333;
+          }
         }
       }
     }
@@ -273,6 +276,9 @@ html, body { height: 100% }
       padding: .25rem;
       font-size: .75rem;
       background: #fffc;
+      html.dark & {
+        background: #000c;
+      }
 
       &.fade-out {
         animation: fade-out-prompt .5s forwards;
@@ -297,6 +303,9 @@ html, body { height: 100% }
       }
       input[type=number] {
         width: 4em;
+      }
+      .error {
+        color: #c00;
       }
       button {
         border: none;
@@ -836,6 +845,7 @@ html, body { height: 100% }
     width: max-content;
     max-width: 80%;
     background: white;
+    color: #002;
     top: 4rem;
     left: 50%;
     transform: translateX(-50%);
@@ -848,6 +858,10 @@ html, body { height: 100% }
     h1, h2, h3, h4, h5, h6 {
       text-align: center;
       margin: .25em 0;
+    }
+
+    html.dark & {
+      background: #cccccf;
     }
   }
 

--- a/src/ui/game/components/Debug.tsx
+++ b/src/ui/game/components/Debug.tsx
@@ -9,7 +9,7 @@ const Debug = () => {
   if (!game) return null;
 
   return (
-    <div id="debug-overlay">
+    <div id="debug-overlay" className="full-page-cover">
       <div id="flow-debug">
         <FlowDebug flow={game.flow.visualize()} nest={0} current={true} />
       </div>

--- a/src/ui/game/components/Element.tsx
+++ b/src/ui/game/components/Element.tsx
@@ -447,6 +447,7 @@ const Element = ({element, json, mode, onSelectElement, onMouseLeave}: {
           [element.constructor.name]: baseClass !== element.constructor.name,
           selected: isSelected && mode === 'game',
           clickable: clickable || invalidSelectionError,
+          invalid: !!invalidSelectionError || (placing && placement?.invalid),
           selectable,
           droppable
         }

--- a/src/ui/game/components/PlayerControls.tsx
+++ b/src/ui/game/components/PlayerControls.tsx
@@ -9,7 +9,7 @@ import type { Argument } from '../../../action/action.js';
 const PlayerControls = ({onSubmit}: {
   onSubmit: (move?: UIMove, args?: Record<string, Argument<Player>>) => void,
 }) => {
-  const [position, controls, boardPrompt, selected, move] = gameStore(s => [s.position, s.controls, s.boardPrompt, s.selected, s.move]);
+  const [position, controls, boardPrompt, error, selected, move] = gameStore(s => [s.position, s.controls, s.boardPrompt, s.error, s.selected, s.move]);
 
   if (!position || !controls) return null;
   if ((!boardPrompt && controls.moves.length === 0 && !move && selected.length === 0 || boardPrompt === '__missing__') && controls.name !== 'disambiguate-board-selection') return null;
@@ -28,6 +28,8 @@ const PlayerControls = ({onSubmit}: {
           {!boardPrompt && pendingMove.prompt && pendingMove.prompt}
         </ActionForm>
       ))}
+
+      {error && <div className="error">{error}</div>}
 
       {(move || selected.length > 0 || controls.name === 'disambiguate-board-selection') && (
         <button onClick={() => onSubmit()}>Cancel</button>

--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -13,7 +13,6 @@ import {
   removePlacementPiece,
   decorateUIMove,
   clearMove,
-  updateControls,
 } from './lib.js';
 
 import type { GameUpdateEvent, GameFinishedEvent, User } from './Main.js'
@@ -74,11 +73,12 @@ export type GameStore = {
   announcementIndex: number;
   dismissAnnouncement: () => void;
   boardSelections: Record<string, {
-    clickMoves: UIMove[],
+    clickMoves: UIMove[];
     dragMoves: {
-      move: UIMove,
-      drag: Selection<Player> | ResolvedSelection<Player>
-    }[]
+      move: UIMove;
+      drag: Selection<Player> | ResolvedSelection<Player>;
+    }[];
+    error?: string;
   }>; // pending moves on board
   disambiguateElement?: { element: GameElement<Player>, moves: UIMove[] };
   selected: GameElement[]; // selected elements on board. these are not committed, analagous to input state in a controlled form
@@ -281,7 +281,12 @@ export const createGameStore = () => createWithEqualityFn<GameStore>()((set, get
   }),
 
   setPlacement: ({ column, row }) => set(s => {
-    if (!s.placement || s.placement.piece.container()!.atPosition({ column, row })) {
+    if (
+      !s.placement ||
+        s.placement.piece.container()!.atPosition({ column, row }) ||
+        s.pendingMoves?.[0].selections[0]?.type !== 'place' ||
+        s.pendingMoves?.[0].selections[0]?.error({ ...s.move?.args, '__placement__': [column, row] })
+    ) {
       return {}
     }
     s.placement.piece.column = column;


### PR DESCRIPTION
WIP

currently action#validate is simply an additional means to prune options from the choice tree or present errors on submission for selections that cannot be simply pruned.

this change enhances the meaning of action#validate to not only prune options from choice tree but also flag the pruned choice with the resultant error message which is displayed to the player if they attempt the invalid selection. this behaviour is in addition to normal tree-shaking, but takes precedence, so an author can choose to provide custom error messages for invalid options, before the tree-shaker removes them.