### PR TITLE
Rotation

### DIFF
--- a/src/board/element.ts
+++ b/src/board/element.ts
@@ -39,7 +39,7 @@ type GenericSorter = string | ((e: GameElement) => number | string)
  * ones from the base GameElement
  */
 export type ElementAttributes<T extends GameElement> =
-  Partial<Pick<T, {[K in keyof T]: K extends keyof GameElement ? never : (T[K] extends (...a:any[]) => any ? never : K)}[keyof T] | 'name' | 'player' | 'row' | 'column'>>
+  Partial<Pick<T, {[K in keyof T]: K extends keyof GameElement ? never : (T[K] extends (...a:any[]) => any ? never : K)}[keyof T] | 'name' | 'player' | 'row' | 'column' | 'rotation'>>
 
 export type ElementContext<P extends Player<P, B> = any, B extends Board<P, B> = any> = {
   game: Game<P, B>;
@@ -288,6 +288,8 @@ export default class GameElement<P extends Player<P, B> = any, B extends Board<P
   row?: number;
 
   column?: number;
+
+  rotation?: number; // degrees
 
   /**
    * The {@link Board} to which this element belongs
@@ -973,7 +975,8 @@ export default class GameElement<P extends Player<P, B> = any, B extends Board<P
     // remove hidden attributes
     if (seenBy !== undefined && !this.isVisibleTo(seenBy)) {
       attrs = Object.fromEntries(Object.entries(attrs).filter(
-        ([attr]) => attr === '_visible' || attr !== 'name' && (this.constructor as typeof GameElement).visibleAttributes?.includes(attr)
+        ([attr]) => ['_visible', 'row', 'column', 'rotation'].includes(attr) ||
+          (attr !== 'name' && (this.constructor as typeof GameElement).visibleAttributes?.includes(attr))
       )) as typeof attrs;
     }
     const json: ElementJSON = Object.assign(serializeObject(attrs, seenBy !== undefined), { className: this.constructor.name });

--- a/src/game.ts
+++ b/src/game.ts
@@ -446,8 +446,8 @@ export default class Game<P extends Player<P, B> = any, B extends Board<P, B> = 
           } else if (parseInt(value).toString() === value) {
             v = parseInt(value);
           }
-          const prop = property as keyof GameElement<P>;
-          if (prop !== 'mine' && prop !== 'owner' && prop !== 'row' && prop !== 'column') element[prop] = v
+          // @ts-ignore
+          element[property] = v;
       })
     };
   }

--- a/src/ui/assets/styles/game.scss
+++ b/src/ui/assets/styles/game.scss
@@ -138,7 +138,7 @@ html, body { height: 100% }
 
     .transform-wrapper {
       position: absolute;
-      transform-origin: top left;
+      transform-origin: center;
       transition: transform .6s, top .6s, left .6s, width .6s, height .6s;
       visibility: hidden;
       &.has-info {

--- a/src/ui/game/components/Element.tsx
+++ b/src/ui/game/components/Element.tsx
@@ -81,10 +81,11 @@ const Element = ({element, json, mode, onSelectElement, onMouseLeave}: {
     return {
       scaleX: previousRender.style.width / newPosition.width,
       scaleY: previousRender.style.height / newPosition.height,
-      translateX: (previousRender.style.left - newPosition.left) / newPosition.width * 100,
-      translateY: (previousRender.style.top - newPosition.top) / newPosition.height * 100,
+      translateX: (previousRender.style.left + previousRender.style.width / 2 - newPosition.left - newPosition.width / 2) / newPosition.width * 100,
+      translateY: (previousRender.style.top + previousRender.style.height / 2 - newPosition.top - newPosition.height / 2) / newPosition.height * 100,
+      rotate: (previousRender.style.rotation ?? 0) - (element.rotation ?? 0)
     };
-  }, [relativeTransform, previousRender, mode, positioning]);
+  }, [relativeTransform, previousRender, mode, positioning, element]);
 
   useEffect(() => {
     if (placing && moveTransform) setPositioning(true);
@@ -236,7 +237,8 @@ const Element = ({element, json, mode, onSelectElement, onMouseLeave}: {
     }
 
     if (moveTransform) {
-      let transformToNew = `translate(${moveTransform.translateX}%, ${moveTransform.translateY}%) scaleX(${moveTransform.scaleX}) scaleY(${moveTransform.scaleY})`;
+      let transformToNew = `translate(${moveTransform.translateX}%, ${moveTransform.translateY}%) scaleX(${moveTransform.scaleX}) scaleY(${moveTransform.scaleY}) rotate(${moveTransform.rotate}deg)`;
+
       if (previousRenderedState.elements[element._t.was!]) previousRenderedState.elements[element._t.was!].movedTo = branch;
       if (dragOffset.element && dragOffset.element === element._t.was) {
         transformToNew = `translate(${dragOffset.x}px, ${dragOffset.y}px) ` + transformToNew;
@@ -249,6 +251,8 @@ const Element = ({element, json, mode, onSelectElement, onMouseLeave}: {
       Object.assign(styleBuilder, {'--transformed-to-old': String(uuid())});
     }
     styleBuilder.fontSize = absoluteTransform.height * 0.04 + 'rem'
+
+    if (element.rotation) styleBuilder.transform = (styleBuilder.transform ?? '') + `rotate(${element.rotation}deg)`;
 
     return styleBuilder;
   }, [element, dragging, mode, moveTransform, branch, dragOffset, previousRenderedState, absoluteTransform]);
@@ -495,7 +499,8 @@ const Element = ({element, json, mode, onSelectElement, onMouseLeave}: {
   element._t.was = branch;
   //console.log('doneMoving', branch);
   if (renderedState[branch]) {
-    renderedState[branch].style = relativeTransform;
+    renderedState[branch].style = relativeTransform ?? {};
+    renderedState[branch].style!.rotation = element.rotation;
     renderedState[branch].attrs = newAttrs;
   }
 

--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -84,8 +84,20 @@ export type GameStore = {
   selected: GameElement[]; // selected elements on board. these are not committed, analagous to input state in a controlled form
   selectElement: (moves: UIMove[], element: GameElement) => void;
   automove?: number;
-  renderedState: Record<string, {key: string, style?: Box, attrs?: Record<string, any>}>;
-  previousRenderedState: { sequence: number, elements: Record<string, {key?: string, style?: Box, attrs?: Record<string, any>, movedTo?: string }> };
+  renderedState: Record<string, {
+    key: string;
+    style?: Box & { rotation?: number };
+    attrs?: Record<string, any>;
+  }>;
+  previousRenderedState: {
+    sequence: number;
+    elements: Record<string, {
+      key?: string;
+      style?: Box & { rotation?: number };
+      attrs?: Record<string, any>;
+      movedTo?: string;
+    }>
+  };
   setBoardSize: () => void;
   dragElement?: string;
   setDragElement: (el?: string) => void;


### PR DESCRIPTION
make `rotation` a first class element property, like `row` and `column`

now, can just say `element.rotation = 90` and no longer need to manage through custom CSS transforms

rotation animation happens automatically between state updates
